### PR TITLE
Coverity Fixes: Unitiailized variables

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/ProtocolHandlerServices/BlackBoxTest/ProtocolHandlerBBTestFunction_2.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/ProtocolHandlerServices/BlackBoxTest/ProtocolHandlerBBTestFunction_2.c
@@ -7617,6 +7617,16 @@ BBTestRegisterProtocolNotifyInterfaceTestCheckPoint4 (
   StatusForGuid109 = EFI_SUCCESS;
   AssertionTypeForGuid109 = EFI_TEST_ASSERTION_PASSED;
 
+  AssertionTypeArrayForGuid108[0] = EFI_TEST_ASSERTION_PASSED;
+  AssertionTypeArrayForGuid108[1] = EFI_TEST_ASSERTION_PASSED;
+  FirstNotifiedTimesArray[0] = 0;
+  FirstNotifiedTimesArray[1] = 0;
+
+  AssertionTypeArrayForGuid110[0] = EFI_TEST_ASSERTION_PASSED;
+  AssertionTypeArrayForGuid110[1] = EFI_TEST_ASSERTION_PASSED;
+  SecondNotifiedTimesArray[0] = 0;
+  SecondNotifiedTimesArray[1] = 0;
+
   Status = CheckForCleanEnvironment (&Numbers);
   if (EFI_ERROR(Status)) {
     StandardLib->RecordAssertion (
@@ -8182,6 +8192,11 @@ BBTestRegisterProtocolNotifyInterfaceTestCheckPoint6 (
   NotifyContextArray[0].Status = 0x5a;
   NotifyContextArray[1].Status = 0x5a;
 
+  FirstNotifyContextArray[0].Status = EFI_SUCCESS;
+  FirstNotifyContextArray[1].Status = EFI_SUCCESS;
+  FirstNotifyContextArray[0].NoHandles = 0;
+  FirstNotifyContextArray[1].NoHandles = 0;
+
   Status1 = gtBS->CreateEvent (
                     EVT_NOTIFY_SIGNAL,
                     TPL_CALLBACK,
@@ -8483,6 +8498,22 @@ BBTestRegisterProtocolNotifyInterfaceTestCheckPoint7 (
 
   StatusForGuid124 = EFI_SUCCESS;
   AssertionTypeForGuid124 = EFI_TEST_ASSERTION_PASSED;
+
+  FirstNotifyContextArray[0].Status = EFI_SUCCESS;
+  FirstNotifyContextArray[1].Status = EFI_SUCCESS;
+  FirstNotifyContextArray[0].NoHandles = 0;
+  FirstNotifyContextArray[1].NoHandles = 0;
+
+  AssertionTypeArrayForGuid123[0] = EFI_TEST_ASSERTION_PASSED;
+  AssertionTypeArrayForGuid123[1] = EFI_TEST_ASSERTION_PASSED;
+
+  SecondNotifyContextArray[0].Status = EFI_SUCCESS;
+  SecondNotifyContextArray[1].Status = EFI_SUCCESS;
+  SecondNotifyContextArray[0].NoHandles = 0;
+  SecondNotifyContextArray[1].NoHandles = 0;
+
+  AssertionTypeArrayForGuid125[0] = EFI_TEST_ASSERTION_PASSED;
+  AssertionTypeArrayForGuid125[1] = EFI_TEST_ASSERTION_PASSED;
 
   Status = CheckForCleanEnvironment (&Numbers);
   if (EFI_ERROR(Status)) {

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigRouting/BlackBoxTest/HIIConfigRoutingBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigRouting/BlackBoxTest/HIIConfigRoutingBBTestConformance.c
@@ -1224,7 +1224,7 @@ BBTestConfigToBlockConformanceTestCheckpoint4(
   EFI_STATUS            Status;
   EFI_STRING            ConfigResp;
   UINT8                 Block[TESTBLOCKZISE];
-  UINTN                 BlockSize; 
+  UINTN                 BlockSize;
   EFI_STRING            Progress;
   EFI_TEST_ASSERTION    AssertionType;
 

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigRouting/BlackBoxTest/HIIConfigRoutingBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigRouting/BlackBoxTest/HIIConfigRoutingBBTestConformance.c
@@ -1170,11 +1170,16 @@ BBTestConfigToBlockConformanceTestCheckpoint3(
   EFI_STRING            ConfigResp;
   UINT8                 Block[TESTBLOCKZISE];
   UINTN                 BlockSize;
+  UINTN                 Index;
   EFI_STRING            Progress;
   EFI_TEST_ASSERTION    AssertionType;
 
   BlockSize = TESTBLOCKZISE;
   Progress = NULL;
+
+  for (Index = 0; Index < TESTBLOCKZISE; Index++) {
+    Block[Index] = 0;
+  }
   
   ConfigResp =L"GUID=970eb94aa0d449f7b980bdaa47d42527&NAME=006a0069006e0039&PATH=958720&OFFSET=5&WIDTH=1&VALUE=57&OFFSET=7&WIDTH=2&VALUE=AA55&a9=qin9";
   
@@ -1219,7 +1224,7 @@ BBTestConfigToBlockConformanceTestCheckpoint4(
   EFI_STATUS            Status;
   EFI_STRING            ConfigResp;
   UINT8                 Block[TESTBLOCKZISE];
-  UINTN                 BlockSize;
+  UINTN                 BlockSize; 
   EFI_STRING            Progress;
   EFI_TEST_ASSERTION    AssertionType;
 

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemBBTestConformance.c
@@ -49,6 +49,8 @@ UpdateInfoFileName (EFI_FILE_INFO **InfoBuffer, CHAR16* ChangeFileName)
   UINTN         Size;
   EFI_FILE_INFO *FileInfo;
 
+  Status = EFI_SUCCESS;
+
   if (InfoBuffer == NULL || ChangeFileName == NULL) {
     return EFI_INVALID_PARAMETER;
   }
@@ -704,6 +706,8 @@ BBTestOpenConformanceTestCheckpoint2 (
   EFI_FILE                  *FileHandle;
   UINTN                     FileNameLength;
   UINTN                     FileIndex;
+
+  RandomValue = 0;
 
   Status = SimpleFileSystem->OpenVolume (SimpleFileSystem, &Root);
   if (EFI_ERROR (Status)) {

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestConformance.c
@@ -574,6 +574,8 @@ BBTestOpenExConformanceTestCheckpoint2 (
   EFI_TPL                   OldTpl;
   UINTN                     Index;
 
+  RandomValue = 0;
+
   //
   // Check if Async File IO is supported
   //

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleTextInputEx/BlackBoxTest/SimpleTextInputExBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleTextInputEx/BlackBoxTest/SimpleTextInputExBBTestConformance.c
@@ -468,6 +468,8 @@ BBTestSetStateConformanceTestCheckpoint1 (
   EFI_TEST_ASSERTION    AssertionType;
   EFI_TPL               OldTpl;
 
+  Status = EFI_SUCCESS;
+
   //
   //Call SetState with KeyToggleState being NULL
   //
@@ -544,6 +546,8 @@ BBTestSetStateConformanceTestCheckpoint2 (
                           0
                           };
 
+  Status = EFI_SUCCESS;
+
   //
   //Call SetState with KeyToggleState being a unsupported bit set
   //
@@ -600,6 +604,8 @@ BBTestRegisterKeyNotifyConformanceTestCheckpoint1 (
   EFI_TEST_ASSERTION    AssertionType;
   VOID                  *NotifyHandle;
   EFI_TPL               OldTpl;
+
+  Status = EFI_SUCCESS;
 
   //
   //Call RegisterKeyNotify with KeyData being NULL
@@ -725,6 +731,8 @@ BBTestRegisterKeyNotifyConformanceTestCheckpoint3 (
 
   Key.Key.UnicodeChar = 'R';
   Key.Key.ScanCode = 0X00;
+
+  Status = EFI_SUCCESS;
 
   //
   //Call RegisterKeyNotify with NotifyHandle being NULL

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTestConformance.c
@@ -1,7 +1,7 @@
 /** @file
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
-  Copyright (c) 2021 - 2023, Arm Inc. All rights reserved.<BR>
+  Copyright (c) 2021 - 2023, 2025 Arm Inc. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -346,7 +346,10 @@ BBTestGetCapabilityConformanceTestCheckpoint2 (
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
 
-  if (!(BootServiceCap.HashAlgorithmBitmap & EFI_TCG2_BOOT_HASH_ALG_SHA256)) {
+  // Verify if system supports SHA256, SHA384, or SHA512 hashing algorithm
+  EFI_TCG2_EVENT_ALGORITHM_BITMAP HashAlgoSupportBitmap = EFI_TCG2_BOOT_HASH_ALG_SHA256 | EFI_TCG2_BOOT_HASH_ALG_SHA384 | EFI_TCG2_BOOT_HASH_ALG_SHA512;
+
+  if (!(BootServiceCap.HashAlgorithmBitmap & HashAlgoSupportBitmap)) {
     StandardLib->RecordMessage (
                      StandardLib,
                      EFI_VERBOSE_LEVEL_DEFAULT,

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Drivers/TestProfile/TestProfile.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Drivers/TestProfile/TestProfile.c
@@ -1209,6 +1209,8 @@ Returns:
 
   commentNo = 0;
 
+  Buffer[0] = NULL;
+
   //
   // File not modified, needn't to write back to the disk
   //

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/MonitorServices/IP4NetworkMonitor/IP4NetworkMonitor.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/MonitorServices/IP4NetworkMonitor/IP4NetworkMonitor.c
@@ -736,6 +736,7 @@ Returns:
     return Status;
   }
 
+  FragFlag.LLFlag = 0;
   FragFlag.LLFlag ^= FragFlag.LLFlag;
 
   //
@@ -1218,6 +1219,7 @@ Returns:
   EFI_STATUS        Status;
   EAS_IP4_FRAG_FLAG FragFlag;
 
+  FragFlag.LLFlag = 0;
   FragFlag.LLFlag ^= FragFlag.LLFlag;
   FragFlag.Flag.SeqId   = HTONL (SeqId);
   FragFlag.Flag.OpCode  = LINK_OPERATION_DATA_ACK;

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/MonitorServices/ManagedNetworkMonitor/ManagedNetworkMonitor.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/MonitorServices/ManagedNetworkMonitor/ManagedNetworkMonitor.c
@@ -850,6 +850,7 @@ Returns:
   }
 
   IsOver = FALSE;
+  FragFlag.LLFlag = 0;
   FragFlag.LLFlag ^= FragFlag.LLFlag;
   FragFlag.Flag.SeqId   = HTONL (Sequence);
   FragFlag.Flag.OpCode  = LINK_OPERATION_DATA;
@@ -879,6 +880,7 @@ Returns:
     //
     // Build App Flag
     //
+    AppFlag.LLFlag = 0;
     AppFlag.LLFlag ^= AppFlag.LLFlag;
     AppSequence = AppSequenceSavedForResend;
     AppFlag.Flag.SeqId = HTONL(AppSequence);
@@ -1174,6 +1176,7 @@ Returns:
   }
 
   IsOver = FALSE;
+  FragFlag.LLFlag = 0;
   FragFlag.LLFlag ^= FragFlag.LLFlag;
 
   RxData = RxToken.Packet.RxData;
@@ -1519,6 +1522,7 @@ Returns:
     return EFI_OUT_OF_RESOURCES;
   }
 
+  FragFlag.LLFlag       = 0;
   FragFlag.LLFlag       ^= FragFlag.LLFlag;
   FragFlag.Flag.SeqId   = HTONL (SeqId);
   FragFlag.Flag.OpCode  = Type;


### PR DESCRIPTION
Fixes for errors found by Coverity as per [https://github.com/tianocore/edk2-test/issues/233](https://github.com/tianocore/edk2-test/issues/233)

Addressing all instances of high impact uninitialized variables